### PR TITLE
Fix byte/string conversion for Python 3.

### DIFF
--- a/websocket.py
+++ b/websocket.py
@@ -312,7 +312,7 @@ Sec-WebSocket-Accept: %s\r
                         offset=full_len - (f['length'] % 4),
                         count=(f['length'] % 4))
                 c = numpy.bitwise_xor(data, mask).tostring()
-            f['payload'] = b + s2b(c)
+            f['payload'] = s2b(b) + s2b(c)
         else:
             print("Unmasked frame: %s" % repr(buf))
             f['payload'] = buf[(f['hlen'] + has_mask * 4):full_len]


### PR DESCRIPTION
Python 3's handling of bytes and strings caused the `Sec-WebSocket-Accept` header to be wrapped in `b'...'`, e.g. like `Sec-WebSocket-Accept: b'qqPS3vItJSiRDxlSVrmaSmAi+MQ='` as well as throwing a `TypeError` at line 315. These issues seem to be resolved by using the `s2b`/`b2s` functions to convert bytes/strings correctly. I'm able to run the tests successfully with both Python 2.7.2 and Python 3.2.2 after applying this patch.
