### PR TITLE
Enable multiple targets with file-based configuration

### DIFF
--- a/websockify
+++ b/websockify
@@ -45,6 +45,7 @@ Traffic Legend:
         self.wrap_mode      = kwargs.pop('wrap_mode')
         self.unix_target    = kwargs.pop('unix_target')
         self.ssl_target     = kwargs.pop('ssl_target')
+        self.target_list    = kwargs.pop('target_list')
         # Last 3 timestamps command was run
         self.wrap_times    = [0, 0, 0]
 
@@ -97,7 +98,11 @@ Traffic Legend:
         else:
             dst_string = "%s:%s" % (self.target_host, self.target_port)
 
-        msg = "  - proxying from %s:%s to %s" % (
+        if self.target_list:
+            msg = "  - proxying from %s:%s to targets in %s" % (
+                self.listen_host, self.listen_port, self.target_list)
+        else:
+            msg = "  - proxying from %s:%s to %s" % (
                 self.listen_host, self.listen_port, dst_string)
 
         if self.ssl_target:
@@ -235,7 +240,7 @@ Traffic Legend:
 
 def websockify_init():
     usage = "\n    %prog [options]"
-    usage += " [source_addr:]source_port target_addr:target_port"
+    usage += " [source_addr:]source_port [target_addr:target_port]"
     usage += "\n    %prog [options]"
     usage += " [source_addr:]source_port -- WRAP_COMMAND_LINE"
     parser = optparse.OptionParser(usage=usage)
@@ -269,10 +274,12 @@ def websockify_init():
     parser.add_option("--prefer-ipv6", "-6",
             action="store_true", dest="source_is_ipv6",
             help="prefer IPv6 when resolving source_addr")
+    parser.add_option("--target-list", metavar="FILE",
+                      help="Configuration file containing valid targets in the form host:port:token or, alternatively, a directory containing configuration files of this form")
     (opts, args) = parser.parse_args()
 
     # Sanity checks
-    if len(args) < 1:
+    if len(args) < 2 and not opts.target_list:
         parser.error("Too few arguments")
     if sys.argv.count('--'):
         opts.wrap_cmd = args[1:]
@@ -297,7 +304,7 @@ def websockify_init():
     try:    opts.listen_port = int(opts.listen_port)
     except: parser.error("Error parsing listen port")
 
-    if opts.wrap_cmd or opts.unix_target:
+    if opts.wrap_cmd or opts.unix_target or opts.target_list:
         opts.target_host = None
         opts.target_port = None
     else:


### PR DESCRIPTION
...tion file.

The --target-list option is used to pass a configuration file on websockify start.

This file contains entries in the form host:port:token, one per line.

When a new connection is open (from noVNC for example), the url should look like:

ws://websockify_host:websockify_port/?token=ABCD

The token is then extracted and checked against the entries in the configuration file.

When the token matches, the connection is proxied to the host:port indicated in the file.

If the configuration file is a folder, then all the entries from files in it are read.
