### PR TITLE
Allow sourcing data from stdin/stdout

### DIFF
--- a/other/websocket.c
+++ b/other/websocket.c
@@ -475,12 +475,17 @@ int parse_handshake(ws_ctx_t *ws_ctx, char *handshake) {
         strncpy(headers->connection, start, end-start);
         headers->connection[end-start] = '\0';
    
+        //RFC 6455 11.3.4 - Sec-WebSocket-Protocol MAY appear multiple times
+        //in a request. Or it may not appear at all.
         start = strstr(handshake, "\r\nSec-WebSocket-Protocol: ");
-        if (!start) { return 0; }
-        start += 26;
-        end = strstr(start, "\r\n");
-        strncpy(headers->protocols, start, end-start);
-        headers->protocols[end-start] = '\0';
+        if (start) {
+            start += 26;
+            end = strstr(start, "\r\n");
+            strncpy(headers->protocols, start, end-start);
+            headers->protocols[end-start] = '\0';
+        } else {
+            headers->protocols[0] = '\0';
+        }
     } else {
         // Hixie 75 or 76
         ws_ctx->hybi = 0;

--- a/other/websocket.c
+++ b/other/websocket.c
@@ -788,6 +788,13 @@ void start_server() {
             break;   // Child process exits
         } else {         // parent process
             settings.handler_id += 1;
+
+            if (settings.one_at_a_time) {
+                //Block on child process exiting
+                handler_msg("Waiting for child to finish\n");
+                wait(pid);
+                handler_msg("Child finished\n");
+            }
         }
     }
     if (pid == 0) {

--- a/other/websocket.h
+++ b/other/websocket.h
@@ -62,6 +62,7 @@ typedef struct {
     int ssl_only;
     int daemon;
     int run_once;
+    int one_at_a_time;
 } settings_t;
 
 

--- a/other/websocket.h
+++ b/other/websocket.h
@@ -79,6 +79,6 @@ ssize_t ws_send(ws_ctx_t *ctx, const void *buf, size_t len);
         fprintf(stream, __VA_ARGS__); \
     }
 
-#define handler_msg(...) gen_handler_msg(stdout, __VA_ARGS__);
+#define handler_msg(...) gen_handler_msg(stderr, __VA_ARGS__);
 #define handler_emsg(...) gen_handler_msg(stderr, __VA_ARGS__);
 


### PR DESCRIPTION
These changes allow sourcing data from stdin to share out to a websocket client. For example:
    ./gen_data.sh | ./websockify 1234
To allow this:
* Logging messages is sent to stderr
* If websockify is using stdin/stdout (target_local = true) then only allow one client to connect at a time
