### PR TITLE
Add authentication/firewall capability through shell call/args

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -2,14 +2,14 @@
 
 import os
 
+#for k,v in os.environ.items():
+#    print k + " = " + v
+
 try:
-    expected = os.environ['EXPECTED_TOKEN']
+    expected = os.environ['WEBSOCKIFY_CLIENT_TOKEN']
     token = os.environ['WEBSOCKIFY_UNSAFE_TOKEN']
 except:
 	exit(-1)
-
-print 'expected = ' + expected
-print 'token = ' + token
 
 if expected == token:
     exit(0)

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os
+
+try:
+    expected = os.environ['EXPECTED_TOKEN']
+    token = os.environ['WEBSOCKIFY_UNSAFE_TOKEN']
+except:
+	exit(-1)
+
+print 'expected = ' + expected
+print 'token = ' + token
+
+if expected == token:
+    exit(0)
+else:
+    exit(1)

--- a/websocket.py
+++ b/websocket.py
@@ -102,11 +102,12 @@ Sec-WebSocket-Accept: %s\r
     def __init__(self, listen_host='', listen_port=None, source_is_ipv6=False,
             verbose=False, cert='', key='', ssl_only=None,
             daemon=False, record='', web='',
-            run_once=False, timeout=0, idle_timeout=0, auth_hook=''):
+            run_once=False, timeout=0, idle_timeout=0, auth_hook='', auth_token=''):
 
         # settings
         self.verbose        = verbose
         self.auth_hook      = auth_hook
+        self.auth_token     = auth_token
         self.listen_host    = listen_host
         self.listen_port    = listen_port
         self.prefer_ipv6    = source_is_ipv6
@@ -778,12 +779,7 @@ Sec-WebSocket-Accept: %s\r
         self.auth_env['WEBSOCKIFY_HOST_RECORD'] = str(self.record)
         self.auth_env['WEBSOCKIFY_HOST_SSL_ONLY'] = str(self.ssl_only)
         self.auth_env['WEBSOCKIFY_HOST_SCHEME'] = self.scheme
-        tmp = "None"
-        try:
-            tmp = os.environ['WEBSOCKIFY_CLIENT_TOKEN'] #pass any expected token
-        except:
-            pass
-        self.auth_env['WEBSOCKIFY_CLIENT_TOKEN'] = tmp
+        self.auth_env['WEBSOCKIFY_CLIENT_TOKEN'] = self.auth_token
         self.auth_env['WEBSOCKIFY_CLIENT_IP'] = address[0]
         self.auth_env['WEBSOCKIFY_CLIENT_PORT'] = str(address[1])
         self.auth_env['WEBSOCKIFY_VNCHOST_IP'] = self.target_host

--- a/websockify
+++ b/websockify
@@ -339,6 +339,9 @@ def websockify_init():
             help="Executable to authenticate client connections. "
             "Ret code 0=authenticated. Client args = WEBSOCKIFY_UNSAFE_* env vars. "
             "'WEBSOCKIFY_CLIENT_*','WEBSOCKIFY_VNCHOST_*','WEBSOCKIFY_HOST_*'")
+    parser.add_option("--auth-token", default="", metavar="a8H6g0sl",
+            help="Expected authentication token client needs to provide "
+            "This is passed to --auth-hook program and internal handler.")
     (opts, args) = parser.parse_args()
 
     # Sanity checks

--- a/websockify
+++ b/websockify
@@ -335,10 +335,10 @@ def websockify_init():
             help="Configuration file containing valid targets "
             "in the form 'token: host:port' or, alternatively, a "
             "directory containing configuration files of this form")
-    parser.add_option("--auth-hook", default="",
-            help="Executable used to authenticate client connection attempts."
-            "Ret code 0=authenticated. Shell args passed through WEBSOCKIFY_UNSAFE_* env vars."
-            "'WEBSOCKIFY_CLIENT_IP','WEBSOCKIFY_VNCHOST_IP','WEBSOCKIFY_VNCHOST_PORT' always available.")
+    parser.add_option("--auth-hook", default="", metavar="cmd",
+            help="Executable to authenticate client connections. "
+            "Ret code 0=authenticated. Client args = WEBSOCKIFY_UNSAFE_* env vars. "
+            "'WEBSOCKIFY_CLIENT_*','WEBSOCKIFY_VNCHOST_*','WEBSOCKIFY_HOST_*'")
     (opts, args) = parser.parse_args()
 
     # Sanity checks

--- a/websockify
+++ b/websockify
@@ -335,6 +335,10 @@ def websockify_init():
             help="Configuration file containing valid targets "
             "in the form 'token: host:port' or, alternatively, a "
             "directory containing configuration files of this form")
+    parser.add_option("--auth-hook", default="",
+            help="Executable used to authenticate client connection attempts."
+            "Ret code 0=authenticated. Shell args passed through WEBSOCKIFY_UNSAFE_* env vars."
+            "'WEBSOCKIFY_CLIENT_IP','WEBSOCKIFY_VNCHOST_IP','WEBSOCKIFY_VNCHOST_PORT' always available.")
     (opts, args) = parser.parse_args()
 
     # Sanity checks

--- a/websockify.py
+++ b/websockify.py
@@ -1,1 +1,0 @@
-websockify


### PR DESCRIPTION
This is based on Cliff Cypher's work. (https://github.com/ccyphers/websockify/commit/852de017686dd930399252ac8f1cda00a15a7a4e)
Let me know what you think. I believe I addressed your notes on his commit request.

I included an example script 'auth.py' to show how token based authentication would work.
This seems to be working fairly well atm.

example call:
./websockify --auth-hook='python auth.py' 10000 host:5900