### PR TITLE
--unix-target option breaks argument sanity check

### DIFF
--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -338,7 +338,7 @@ def websockify_init():
     (opts, args) = parser.parse_args()
 
     # Sanity checks
-    if len(args) < 2 and not opts.target_cfg:
+    if len(args) < 2 and not (opts.target_cfg or opts.unix_target):
         parser.error("Too few arguments")
     if sys.argv.count('--'):
         opts.wrap_cmd = args[1:]


### PR DESCRIPTION
I tried to use websockify with --unix-taget=path and it said "error: Too few arguments" so I added it to the sanity chack.
Please check the patch.
