### PR TITLE
Reset SIGPIPE handler when calling Popen

### DIFF
--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -11,7 +11,7 @@ as taken from http://docs.python.org/dev/library/ssl.html#certificates
 
 '''
 
-import socket, optparse, time, os, sys, subprocess
+import signal, socket, optparse, time, os, sys, subprocess
 from select import select
 import websocket
 try:    from urllib.parse import parse_qs, urlparse
@@ -87,7 +87,7 @@ Traffic Legend:
         self.wrap_times.append(time.time())
         self.wrap_times.pop(0)
         self.cmd = subprocess.Popen(
-                self.wrap_cmd, env=os.environ)
+                self.wrap_cmd, env=os.environ, preexec_fn=_subprocess_setup)
         self.spawn_message = True
 
     def started(self):
@@ -144,7 +144,7 @@ Traffic Legend:
                 else:
                     self.run_wrap_cmd()
 
-    # 
+    #
     # Routines above this point are run in the master listener
     # process.
     #
@@ -171,7 +171,7 @@ Traffic Legend:
         else:
             msg = "connecting to: %s:%s" % (
                                     self.target_host, self.target_port)
-        
+
         if self.ssl_target:
             msg += " (using SSL)"
         self.msg(msg)
@@ -291,6 +291,13 @@ Traffic Legend:
                         self.target_host, self.target_port))
                     raise self.CClose(closed['code'], closed['reason'])
 
+
+def _subprocess_setup():
+    # Python installs a SIGPIPE handler by default. This is usually not what
+    # non-Python successfulbprocesses expect.
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+
 def websockify_init():
     usage = "\n    %prog [options]"
     usage += " [source_addr:]source_port [target_addr:target_port]"
@@ -349,7 +356,7 @@ def websockify_init():
 
     if not websocket.ssl and opts.ssl_target:
         parser.error("SSL target requested and Python SSL module not loaded.");
-        
+
     if opts.ssl_only and not os.path.exists(opts.cert):
         parser.error("SSL only and %s not found" % opts.cert)
 


### PR DESCRIPTION
Python ignores SIGPIPE on startup, because it prefers to check every write
and raise an IOError exception rather than taking the signal. Most Unix
subprocesses don't expect to work this way. This patch (adapted from Colin
Watson's post at http://tinyurl.com/2a7mzh5) sets SIGPIPE back to the default
action.
