### PR TITLE
Import everything in websocketproxy and websocket

### DIFF
--- a/websockify/__init__.py
+++ b/websockify/__init__.py
@@ -1,1 +1,2 @@
-import websocket, websocketproxy
+from websocket import *
+from websocketproxy import *


### PR DESCRIPTION
Old users of the websockify library used websockify.WebSocketProxy The
refactor into a module unneccessarily broke this import. The current imports
in **init**.py don't actually do anything so this patch changes the import to
import everything so that the old import still works. This appears to be the
original intention of the existing import statements.
