### PR TITLE
updated version in setup.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+0.2.1 - Oct 15, 2012
+--------------------
+
+ * re-released with updated version number
+
 0.2.0 - Sep 17, 2012
 --------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.1.0'
+version = '0.2.1'
 name = 'websockify'
 long_description = open("README.md").read() + "\n" + \
     open("CHANGES.txt").read() + "\n"


### PR DESCRIPTION
installing the egg with buildout doesn't work as setup.py still stated version 0.1.0 (although release was tagged with 0.2.0
