### PR TITLE
Eliminate attribute errors on last code/msg

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -621,15 +621,23 @@ Sec-WebSocket-Accept: %s\r
             stype = "Plain non-SSL (ws://)"
 
         wsh = WSRequestHandler(retsock, address, not self.web)
-        if wsh.last_code == 101:
+ 
+        try:
+            last_code = wsh.last_code
+            last_message = wsh.last_message
+        except AttributeError:
+            last_code = 0
+            last_message = None
+ 
+        if last_code == 101:
             # Continue on to handle WebSocket upgrade
             pass
-        elif wsh.last_code == 405:
+        elif last_code == 405:
             raise self.EClose("Normal web request received but disallowed")
-        elif wsh.last_code < 200 or wsh.last_code >= 300:
-            raise self.EClose(wsh.last_message)
-        elif self.verbose:
-            raise self.EClose(wsh.last_message)
+        elif last_code < 200 or last_code >= 300 and last_message:
+            raise self.EClose(last_message)
+        elif self.verbose and last_message:
+            raise self.EClose(last_message)
         else:
             raise self.EClose("")
 


### PR DESCRIPTION
When using websockify via nova-vncproxy or nova-spiceproxy, there is a continuous stream of exceptions such as the following:

126: Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/websockify/websocket.py", line 774, in top_new_client
self.client = self.do_handshake(startsock, address)
File "/usr/lib/python2.7/dist-packages/websockify/websocket.py", line 706, in do_handshake
if wsh.last_code == 101:
AttributeError: WSRequestHandler instance has no attribute 'last_code'

This patch checks for the existence of last_code and last_message via exception handler.  There may be a better way to fix this issue but this worked for me.
