### PR TITLE
Enable Process Reaping in All Conditions

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -754,9 +754,7 @@ Sec-WebSocket-Accept: %s\r
 
         # Allow override of SIGINT
         signal.signal(signal.SIGINT, self.do_SIGINT)
-        if not multiprocessing:
-            # os.fork() (python 2.4) child reaper
-            signal.signal(signal.SIGCHLD, self.fallback_SIGCHLD)
+        signal.signal(signal.SIGCHLD, self.fallback_SIGCHLD)
 
         last_active_time = self.launch_time
         while True:


### PR DESCRIPTION
Process reaping via the SIGCHLD handler is now enabled in all
circumstances, instead of just when os.fork is being used.

Fixes #95
