### PR TITLE
WebSocketProxy: support non path target_cfg

### DIFF
--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -83,9 +83,6 @@ Traffic Legend:
                 "REBIND_OLD_PORT": str(kwargs['listen_port']),
                 "REBIND_NEW_PORT": str(self.target_port)})
 
-        if self.target_cfg:
-            self.target_cfg = os.path.abspath(self.target_cfg)
-
         websocket.WebSocketServer.__init__(self, *args, **kwargs)
 
     def run_wrap_cmd(self):
@@ -387,6 +384,10 @@ def websockify_init():
             parser.error("Error parsing target")
         try:    opts.target_port = int(opts.target_port)
         except: parser.error("Error parsing target port")
+
+    # Transform to absolute path as daemon may chdir
+    if opts.target_cfg:
+        opts.target_cfg = os.path.abspath(opts.target_cfg)
 
     # Create and start the WebSockets proxy
     server = WebSocketProxy(**opts.__dict__)


### PR DESCRIPTION
The WebSocketProxy class is usable for creating derived applications
with different logic, especially for the target validation.

Current code assumes that target is a path while in other implementation
it can be object that is loaded at initialization.

This change moves the conversion to absolute path into main function, so
that the WebSocketProxy class will not make that assumption.

Signed-off-by: Alon Bar-Lev alon.barlev@gmail.com
