### PR TITLE
Fix crash when module is missing

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -58,7 +58,7 @@ for mod, msg in [('numpy', 'HyBi protocol will be slower'),
         globals()[mod] = __import__(mod)
     except ImportError:
         globals()[mod] = None
-        self.msg("WARNING: no '%s' module, %s", mod, msg)
+        print("WARNING: no '%s' module, %s" % (mod, msg))
 if multiprocessing and sys.platform == 'win32':
     # make sockets pickle-able/inheritable
     import multiprocessing.reduction


### PR DESCRIPTION
I had a problem on a host where numpy is missing (python 2.7.3). Websockify would throw the following exception

```
self.msg("WARNING: no '%s' module, %s", mod, msg)
NameError: name 'self' is not defined
```

`self.msg` is not available when checking the imports. 
