### PR TITLE
Added temp dir for unit test data and cleanup

### DIFF
--- a/tests/test_websocketproxy.py
+++ b/tests/test_websocketproxy.py
@@ -15,11 +15,15 @@
 #    under the License.
 
 """ Unit tests for websocketproxy """
-import unittest
-import time
-import subprocess
-import stubout
+import os
+import logging
 import select
+import shutil
+import stubout
+import subprocess
+import tempfile
+import time
+import unittest
 
 from websockify import websocketproxy
 
@@ -37,20 +41,42 @@ class MockSocket(object):
 
 class WebSocketProxyTest(unittest.TestCase):
 
+    def _init_logger(self, tmpdir):
+        name = 'websocket-unittest'
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = True
+        filename = "%s.log" % (name)
+        handler = logging.FileHandler(filename)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+
     def setUp(self):
         """Called automatically before each test."""
         super(WebSocketProxyTest, self).setUp()
-
         self.soc = ''
         self.stubs = stubout.StubOutForTesting()
+        # Temporary dir for test data
+        self.tmpdir = tempfile.mkdtemp()
+        # Put log somewhere persistent
+        self._init_logger('./')
+        # Mock this out cause it screws tests up
+        self.stubs.Set(os, 'chdir', lambda *args, **kwargs: None)
 
     def tearDown(self):
         """Called automatically after each test."""
         self.stubs.UnsetAll()
+        shutil.rmtree(self.tmpdir)
         super(WebSocketProxyTest, self).tearDown()
 
+    def _get_websockproxy(self, **kwargs):
+        return websocketproxy.WebSocketProxy(key=self.tmpdir,
+                                             web=self.tmpdir,
+                                             record=self.tmpdir,
+                                             **kwargs)
+
     def test_run_wrap_cmd(self):
-        web_socket_proxy = websocketproxy.WebSocketProxy()
+        web_socket_proxy = self._get_websockproxy()
         web_socket_proxy.__dict__["wrap_cmd"] = "wrap_cmd"
 
         def mock_Popen(*args, **kwargs):
@@ -61,7 +87,7 @@ class WebSocketProxyTest(unittest.TestCase):
         self.assertEquals(web_socket_proxy.spawn_message, True)
 
     def test_started(self):
-        web_socket_proxy = websocketproxy.WebSocketProxy()
+        web_socket_proxy = self._get_websockproxy()
         web_socket_proxy.__dict__["spawn_message"] = False
         web_socket_proxy.__dict__["wrap_cmd"] = "wrap_cmd"
 
@@ -73,7 +99,7 @@ class WebSocketProxyTest(unittest.TestCase):
         self.assertEquals(web_socket_proxy.__dict__["spawn_message"], True)
 
     def test_poll(self):
-        web_socket_proxy = websocketproxy.WebSocketProxy()
+        web_socket_proxy = self._get_websockproxy()
         web_socket_proxy.__dict__["wrap_cmd"] = "wrap_cmd"
         web_socket_proxy.__dict__["wrap_mode"] = "respawn"
         web_socket_proxy.__dict__["wrap_times"] = [99999999]
@@ -84,7 +110,7 @@ class WebSocketProxyTest(unittest.TestCase):
         self.assertEquals(web_socket_proxy.spawn_message, False)
 
     def test_new_client(self):
-        web_socket_proxy = websocketproxy.WebSocketProxy()
+        web_socket_proxy = self._get_websockproxy()
         web_socket_proxy.__dict__["verbose"] = "verbose"
         web_socket_proxy.__dict__["daemon"] = None
         web_socket_proxy.__dict__["client"] = "client"

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py24, py25, py26, py27, py30
+envlist = py24,py25,py26,py27,py30
 setupdir = ../
 
 [testenv]
@@ -12,3 +12,9 @@ commands = nosetests {posargs}
 deps =
     mox
     nose
+
+# At some point we should enable this since tox epdctes it to exist but
+# the code will need pep8ising first. 
+#[testenv:pep8]
+#commands = flake8
+#dep = flake8


### PR DESCRIPTION
Unit test data will now go to a temporary dir that will be deleted
once the test completes. The unit tests also setup a logger which
will persist so that it can be inspected once tests complete.

Also fixes a bug where instance var is missing from decode_hybi()

Co-authored-by: natsume.takashi@lab.ntt.co.jp
