### PR TITLE
Rename self.client and new_client - prepare for #72 / #111

### DIFF
--- a/other/websocket.rb
+++ b/other/websocket.rb
@@ -98,7 +98,7 @@ Sec-WebSocket-Accept: %s\r
 
     begin
       t[:client] = do_handshake(io)
-      new_client(t[:client])
+      new_websocket_client(t[:client])
     rescue EClose => e
       msg "Client closed: #{e.message}"
       return

--- a/other/websockify.rb
+++ b/other/websockify.rb
@@ -39,7 +39,7 @@ Traffic Legend:
   end
 
   # Echo back whatever is received    
-  def new_client(client)
+  def new_websocket_client(client)
 
     msg "connecting to: %s:%s" % [@target_host, @target_port]
     tsock = TCPSocket.open(@target_host, @target_port)

--- a/tests/echo.py
+++ b/tests/echo.py
@@ -20,7 +20,7 @@ class WebSocketEcho(WebSocketServer):
     client.  """
     buffer_size = 8096
 
-    def new_client(self):
+    def new_websocket_client(self):
         """
         Echo back whatever is received.
         """

--- a/tests/echo.rb
+++ b/tests/echo.rb
@@ -12,7 +12,7 @@ require 'websocket'
 class WebSocketEcho < WebSocketServer
 
   # Echo back whatever is received    
-  def new_client(client)
+  def new_websocket_client(client)
 
     cqueue = []
     c_pend = 0

--- a/tests/load.py
+++ b/tests/load.py
@@ -29,7 +29,7 @@ class WebSocketLoad(WebSocketServer):
 
         WebSocketServer.__init__(self, *args, **kwargs)
 
-    def new_client(self):
+    def new_websocket_client(self):
         self.send_cnt = 0
         self.recv_cnt = 0
 

--- a/tests/test_websocketproxy.py
+++ b/tests/test_websocketproxy.py
@@ -124,4 +124,4 @@ class WebSocketProxyTest(unittest.TestCase):
             return ins, outs, excepts
 
         self.stubs.Set(select, 'select', mock_select)
-        self.assertRaises(Exception, web_socket_proxy.new_client)
+        self.assertRaises(Exception, web_socket_proxy.new_websocket_client)

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -68,7 +68,7 @@ if multiprocessing and sys.platform == 'win32':
 class WebSocketServer(object):
     """
     WebSockets server class.
-    Must be sub-classed with new_client method definition.
+    Must be sub-classed with new_websocket_client method definition.
     """
 
     log_prefix = "websocket"
@@ -770,7 +770,7 @@ Sec-WebSocket-Accept: %s\r
                     self.rec.write("var VNC_frame_data = [\n")
 
                 self.ws_connection = True
-                self.new_client()
+                self.new_websocket_client()
             except self.CClose:
                 # Close the client
                 _, exc, _ = sys.exc_info()
@@ -797,15 +797,15 @@ Sec-WebSocket-Accept: %s\r
                 # Original socket closed by caller
                 self.request.close()
 
-    def new_client(self):
+    def new_websocket_client(self):
         """ Do something with a WebSockets client connection. """
-        raise("WebSocketServer.new_client() must be overloaded")
+        raise("WebSocketServer.new_websocket_client() must be overloaded")
 
     def start_server(self):
         """
         Daemonize if requested. Listen for for connections. Run
         do_handshake() method for each connection. If the connection
-        is a WebSockets client then call new_client() method (which must
+        is a WebSockets client then call new_websocket_client() method (which must
         be overridden) for each new client connection.
         """
         lsock = self.socket(self.listen_host, self.listen_port, False,

--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -157,7 +157,7 @@ Traffic Legend:
     # will be run in a separate forked process for each connection.
     #
 
-    def new_client(self):
+    def new_websocket_client(self):
         """
         Called after a new WebSocket connection has been established.
         """


### PR DESCRIPTION
In order to prepare for merging #72 / #111, this pull renames self.client to self.request, and new_client() to new_websocket_client(). This makes the diff between the branches much smaller, and makes the actual code changes more visible. 
