### PR TITLE
Update package.json

### DIFF
--- a/other/js/package.json
+++ b/other/js/package.json
@@ -9,9 +9,6 @@
     "url": "git://github.com/kanaka/websockify.git"
   },
   "files": ["../../docs/LICENSE.LGPL-3"],
-  "bin": {
-    "websockify": "./websockify.js"
-  },
   "engines": {
     "node": ">=0.8.9"
   },


### PR DESCRIPTION
Fixed an issue with installing where websockify.js isnt a binary
Removing websockify.js from bin section allows it to install properly.

Log Below:
npm ERR! Error: ENOENT, chmod '/opt/nodevnc/node_modules/websockify/websockify.js'
npm ERR! If you need help, you may report this log at:
npm ERR!     http://github.com/isaacs/npm/issues
npm ERR! or email it to:
npm ERR!     npm-@googlegroups.com

npm ERR! System Linux 3.13.0-24-generic
npm ERR! command "/usr/local/bin/node" "/usr/local/bin/npm" "install" "node_modules/websockify/"
npm ERR! cwd /opt/nodevnc
npm ERR! node -v v0.10.21
npm ERR! npm -v 1.3.11
npm ERR! path /opt/nodevnc/node_modules/websockify/websockify.js
npm ERR! code ENOENT
npm ERR! errno 34
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /opt/nodevnc/npm-debug.log
npm ERR! not ok code 0
