### PR TITLE
Remove explicit numpy requirement from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name=name,
 
       packages=['websockify'],
       include_package_data=True,
-      install_requires=['numpy'],
       zip_safe=False,
       entry_points={
         'console_scripts': [


### PR DESCRIPTION
According to the code, numpy is optional, not required.
(It improves the efficiency of hybi, but there's a fallback).