### PR TITLE
Don't use implicit relative imports

### DIFF
--- a/websockify/__init__.py
+++ b/websockify/__init__.py
@@ -1,2 +1,2 @@
-from websocket import *
-from websocketproxy import *
+from websockify.websocket import *
+from websockify.websocketproxy import *

--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -17,7 +17,7 @@ except: from SocketServer import ForkingMixIn
 try:    from http.server import HTTPServer
 except: from BaseHTTPServer import HTTPServer
 from select import select
-import websocket
+from websockify import websocket
 try:
     from urllib.parse import parse_qs, urlparse
 except:


### PR DESCRIPTION
Implicit relative imports don't work in Python 3.  This converts
implicit relative imports into absolute imports
(e.g. `import websocket` becomes `from websockify import websocket`).

Fixes #154