### PR TITLE
Add Python 3 trove classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,12 @@ setup(name=name,
       long_description=long_description,
       classifiers=[
           "Programming Language :: Python",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 2.6",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.3",
+          "Programming Language :: Python :: 3.4"
         ],
       data_files=[('share/websockify/include',
                       ['include/util.js',


### PR DESCRIPTION
This makes <http://py3readiness.org> display the status of this package correctly :).