### PR TITLE
don't make numpy a hard requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(name=name,
 
       packages=['websockify'],
       include_package_data=True,
-      install_requires=['numpy'],
       zip_safe=False,
       entry_points={
         'console_scripts': [


### PR DESCRIPTION
the websockify code works without numpy. It will be slower, however it
only seems to be used if you are directly processing masked buffers in
python. However, the current code hard enforces numpy in setup.py, so
if you install the package you forcably get numpy.

In OpenStack we use the websockify proxy a lot of places where the
numpy paths aren't touched. Forcing numpy to be installed in all these
circumstances is somewhat overkill.

This would take it out of forced requirements.