### PR TITLE
Make `run` respect virtualenv configuration

### DIFF
--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import websockify
 


### PR DESCRIPTION
Similar to websocify.py, just a convenience fix.