### PR TITLE
Avoid UnboundLocalError for exc

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -1047,6 +1047,7 @@ class WebSocketServer(object):
                         self.msg("In exit")
                         break
                     except Exception:
+                        _, exc, _ = sys.exc_info()
                         self.msg("handler exception: %s", str(exc))
                         self.vmsg("exception", exc_info=True)
 


### PR DESCRIPTION
Previously exc was set only when an exception occurs in the inner
try (the one contains call to self.poll), so an error in the other
part causes an UnboundLocalError.