### PR TITLE
Drop pkrumins/node-base64 dependency

### DIFF
--- a/other/js/package.json
+++ b/other/js/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "ws": ">=0.4.27",
-    "base64": "latest",
     "optimist": "latest",
     "policyfile": "latest"
   }


### PR DESCRIPTION
Since 805026360e591ef6b27eb069e90ffccb31f72d1f this dependency has not been in use.

It also prevents using Websockify on Node v0.12.0:

```
npm WARN package.json websockify@0.7.0 license should be a valid SPDX license expression
-
> base64@2.1.0 install /Users/timkurvers/Projects/forks/websockify/other/js/node_modules/base64
> node-gyp rebuild

  CXX(target) Release/obj.target/base64/base64.o
../base64.cc:13:17: error: calling a protected constructor of class 'v8::HandleScope'
    HandleScope scope;
                ^
/Users/timkurvers/.node-gyp/0.12.6/deps/v8/include/v8.h:816:13: note: declared protected here
  V8_INLINE HandleScope() {}
            ^
../base64.cc:14:52: error: no member named 'New' in 'v8::String'
    return ThrowException(Exception::Error(String::New(msg)));
                                           ~~~~~~~~^
../base64.cc:122:29: error: unknown type name 'Arguments'; did you mean 'v8::internal::Arguments'?
base64_encode_binding(const Arguments &args)
                            ^~~~~~~~~
                            v8::internal::Arguments

...

fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make: *** [Release/obj.target/base64/base64.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
```