### PR TITLE
Ignore node_modules correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 other/.lein-deps-sum
 other/classes
 other/lib
-other/node_modules
+other/js/node_modules
 .project
 .pydevproject
 target.cfg


### PR DESCRIPTION
36cb8f4676c7b5ff34bd22ad729e00e77efb6f00 moved the JavaScript source, but the entry ignoring `node_modules` was not updated in unison.