### PR TITLE
Correct SPDX license identifier for LGPL-3.0

### DIFF
--- a/other/js/package.json
+++ b/other/js/package.json
@@ -2,7 +2,7 @@
   "author": "Joel Martin <github@martintribe.org> (http://github.com/kanaka)",
   "name": "websockify",
   "description": "websockify is a WebSocket-to-TCP proxy/bridge",
-  "license": "LGPL-3",
+  "license": "LGPL-3.0",
   "version": "0.7.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the following warning on `npm install`:

```
npm WARN package.json websockify@0.7.0 license should be a valid SPDX license expression
```

The identifier LGPL-3.0 was retrieved from https://spdx.org/licenses/.