### PR TITLE
Removed base64 dedpendancy

### DIFF
--- a/other/js/package.json
+++ b/other/js/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "ws": ">=0.4.27",
-    "base64": "latest",
     "optimist": "latest",
     "policyfile": "latest"
   }


### PR DESCRIPTION
`base64` npm package no longer compiles on my machine and `npm install` fails. So I removed as it is no longer used by websockify.js