### PR TITLE
Fix bug in JSONTokenApi plugin

### DIFF
--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -79,4 +79,4 @@ class JSONTokenApi(BaseTokenAPI):
     # should go
 
     def process_result(self, resp):
-        return (resp.json['host'], resp.json['port'])
+        return (str(resp.json()['host']), str(resp.json()['port']))


### PR DESCRIPTION
Fixes:
>handler exception: 'method' object is not subscriptable
exception
Traceback (most recent call last):
  File "/root/websockify/websockify/websocket.py", line 910, in top_new_client
    client = self.do_handshake(startsock, address)
  File "/root/websockify/websockify/websocket.py", line 845, in do_handshake
    self.RequestHandlerClass(retsock, address, self)
  File "/root/websockify/websockify/websocket.py", line 114, in __init__
    SimpleHTTPRequestHandler.__init__(self, req, addr, server)
  File "/usr/lib/python3.4/socketserver.py", line 673, in __init__
    self.handle()
Fixes: 
 File "/root/websockify/websockify/websocket.py", line 570, in handle
    SimpleHTTPRequestHandler.handle(self)
  File "/usr/lib/python3.4/http/server.py", line 398, in handle
    self.handle_one_request()
  File "/usr/lib/python3.4/http/server.py", line 386, in handle_one_request
    method()
  File "/root/websockify/websockify/websocket.py", line 536, in do_GET
    if not self.handle_websocket():
  File "/root/websockify/websockify/websocket.py", line 524, in handle_websocket
    self.new_websocket_client()
  File "/root/websockify/websockify/websocketproxy.py", line 48, in new_websocket_client
    (self.server.target_host, self.server.target_port) = self.get_target(self.server.token_plugin, self.path)
  File "/root/websockify/websockify/websocketproxy.py", line 103, in get_target
    result_pair = target_plugin.lookup(token)
  File "/root/websockify/websockify/token_plugins.py", line 72, in lookup
    return self.process_result(resp)
  File "/root/websockify/websockify/token_plugins.py", line 82, in process_result
    return (resp.json['host'], resp.json['port'])
TypeError: 'method' object is not subscriptable
