### PR TITLE
Rework Auth Plugins to Support HTTP Auth

### DIFF
--- a/websockify/auth_plugins.py
+++ b/websockify/auth_plugins.py
@@ -7,7 +7,15 @@ class BasePlugin(object):
 
 
 class AuthenticationError(Exception):
-    pass
+    def __init__(self, log_msg=None, response_code=403, response_headers={}, response_msg=None):
+        self.code = response_code
+        self.headers = response_headers
+        self.msg = response_msg
+
+        if log_msg is None:
+            log_msg = response_msg
+
+        super(AuthenticationError, self).__init__('%s %s' % (self.code, log_msg))
 
 
 class InvalidOriginError(AuthenticationError):
@@ -16,8 +24,44 @@ class InvalidOriginError(AuthenticationError):
         self.actual_origin = actual
 
         super(InvalidOriginError, self).__init__(
-            "Invalid Origin Header: Expected one of "
-            "%s, got '%s'" % (expected, actual))
+            response_msg='Invalid Origin',
+            log_msg="Invalid Origin Header: Expected one of "
+                    "%s, got '%s'" % (expected, actual))
+
+
+class BasicHTTPAuth(object):
+    def __init__(self, src=None):
+        self.src = src
+
+    def authenticate(self, headers, target_host, target_port):
+        import base64
+
+        auth_header = headers.get('Authorization')
+        if auth_header:
+            if not auth_header.startswith('Basic '):
+                raise AuthenticationError(response_code=403)
+
+            try:
+                user_pass_raw = base64.b64decode(auth_header[6:])
+            except TypeError:
+                raise AuthenticationError(response_code=403)
+
+            user_pass = user_pass_raw.split(':', 1)
+            if len(user_pass) != 2:
+                raise AuthenticationError(response_code=403)
+
+            if not self.validate_creds:
+                raise AuthenticationError(response_code=403)
+
+        else:
+            raise AuthenticationError(response_code=401,
+                                      response_headers={'WWW-Authenticate': 'Basic realm="Websockify"'})
+
+    def validate_creds(username, password):
+        if '%s:%s' % (username, password) == self.src:
+            return True
+        else:
+            return False
 
 class ExpectOrigin(object):
     def __init__(self, src=None):

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -474,8 +474,12 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
         """Upgrade a connection to Websocket, if requested. If this succeeds,
         new_websocket_client() will be called. Otherwise, False is returned.
         """
+
         if (self.headers.get('upgrade') and
             self.headers.get('upgrade').lower() == 'websocket'):
+
+            # ensure connection is authorized, and determine the target
+            self.validate_connection()
 
             if not self.do_websocket_handshake():
                 return False
@@ -548,6 +552,10 @@ class WebSocketRequestHandler(SimpleHTTPRequestHandler):
     def new_websocket_client(self):
         """ Do something with a WebSockets client connection. """
         raise Exception("WebSocketRequestHandler.new_websocket_client() must be overloaded")
+
+    def validate_connection(self):
+        """ Ensure that the connection is a valid connection, and set the target. """
+        pass
 
     def do_HEAD(self):
         if self.only_upgrade:
@@ -789,7 +797,7 @@ class WebSocketServer(object):
         """
         ready = select.select([sock], [], [], 3)[0]
 
-        
+
         if not ready:
             raise self.EClose("ignoring socket not ready")
         # Peek, but do not read the data so that we have a opportunity
@@ -903,7 +911,7 @@ class WebSocketServer(object):
 
     def top_new_client(self, startsock, address):
         """ Do something with a WebSockets client connection. """
-        # handler process        
+        # handler process
         client = None
         try:
             try:


### PR DESCRIPTION
This commit reworks auth plugins slightly to enable
support for HTTP authentication.  By raising an
AuthenticationError, auth plugins can now return
HTTP responses to the upgrade request (such as 401).

Related to kanaka/noVNC#522