### PR TITLE
Remove additional signal calls in websockify that causes novnc to hang

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -895,11 +895,14 @@ class WebSocketServer(object):
         raise self.Terminate()
 
     def multiprocessing_SIGCHLD(self, sig, stack):
-        self.vmsg('Reaping zombies, active child count is %s', len(multiprocessing.active_children()))
+        # TODO: figure out a way to actually log this information without
+        #       calling `log` in the signal handlers
+        multiprocessing.active_children()
 
     def fallback_SIGCHLD(self, sig, stack):
         # Reap zombies when using os.fork() (python 2.4)
-        self.vmsg("Got SIGCHLD, reaping zombies")
+        # TODO: figure out a way to actually log this information without
+        #       calling `log` in the signal handlers
         try:
             result = os.waitpid(-1, os.WNOHANG)
             while result[0]:
@@ -909,11 +912,13 @@ class WebSocketServer(object):
             pass
 
     def do_SIGINT(self, sig, stack):
-        self.msg("Got SIGINT, exiting")
+        # TODO: figure out a way to actually log this information without
+        #       calling `log` in the signal handlers
         self.terminate()
 
     def do_SIGTERM(self, sig, stack):
-        self.msg("Got SIGTERM, exiting")
+        # TODO: figure out a way to actually log this information without
+        #       calling `log` in the signal handlers
         self.terminate()
 
     def top_new_client(self, startsock, address):


### PR DESCRIPTION
    Openstack nova novnc-proxy services uses websockify to provide support
    for nova vms using novnc proxy. At present, novnc hangs every couple of
    weeks. It only resumes post restart of the novnc-proxy which is not
    good. Hence, this code in websockify is updated to get rid of additional
    signal calls to avoid novnc going in hang state even though process is
    running. Basically, we are getting rid of existing msg and vmsg calls in
    the websocket.py. This is kind of quick fix but we will need an
    additional way of figuring out the logging to make it easy to trace in
    case of any further failures in future.

    closes bug: https://github.com/kanaka/noVNC/issues/556