### PR TITLE
websockify does not react to SIGTERM

### DIFF
--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -1079,6 +1079,16 @@ class WebSocketServer(object):
 
                     except (self.Terminate, SystemExit, KeyboardInterrupt):
                         self.msg("In exit")
+                        # terminate all child processes
+                        if multiprocessing and not self.run_once:
+                            childs = multiprocessing.active_children()
+
+                            for child in childs:
+                                pid = child.pid
+                                if pid != os.getpid():
+                                    self.msg("Terminating child %s" % pid)
+                                    os.kill(pid, signal.SIGTERM)
+
                         break
                     except Exception:
                         exc = sys.exc_info()[1]

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -1087,7 +1087,7 @@ class WebSocketServer(object):
                                 pid = child.pid
                                 if pid != os.getpid():
                                     self.msg("Terminating child %s" % pid)
-                                    os.kill(pid, signal.SIGTERM)
+                                    child.terminate()
 
                         break
                     except Exception:


### PR DESCRIPTION
Child processes are not terminated when parent process of websockify
is killed.

In this fix made provision to terminate all child processes when
parent process is killed.

Fixes #138