### PR TITLE
Enable unix socket to work with token plugin

### DIFF
--- a/tests/test_websocketproxy.py
+++ b/tests/test_websocketproxy.py
@@ -93,6 +93,16 @@ class ProxyRequestHandlerTestCase(unittest.TestCase):
         self.assertEqual(host, "some host")
         self.assertEqual(port, "some port")
 
+    def test_get_target_unix_socket(self):
+        class TestPlugin(token_plugins.BasePlugin):
+            def lookup(self, token):
+                return ("unix_socket", "/tmp/socket")
+
+        _, socket = self.handler.get_target(
+            TestPlugin(None), self.handler.path)
+
+        self.assertEqual(socket, "/tmp/socket")
+
     def test_get_target_raises_error_on_unknown_token(self):
         class TestPlugin(token_plugins.BasePlugin):
             def lookup(self, token):

--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -48,8 +48,14 @@ Traffic Legend:
         self.end_headers()
     
     def validate_connection(self):
-        if self.server.token_plugin: 
-            (self.server.target_host, self.server.target_port) = self.get_target(self.server.token_plugin, self.path)
+        if self.server.token_plugin:
+            host, port = self.get_target(self.server.token_plugin, self.path)
+            if host == 'unix_socket':
+                self.server.unix_target = port
+
+            else:
+                self.server.target_host = host
+                self.server.target_port = port
 
         if self.server.auth_plugin:
             try:


### PR DESCRIPTION
This commit adds support to unix sockets in the token plugin, thus it is
possible to have a token files like:

  token: unix_socket:/path/to/socket_file

A single websockify instance will be able to handle multiple sockets.

Signed-off-by: Jose Ricardo Ziviani <jose@ziviani.net>