### PR TITLE
Switch test dependency to mox3

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-mox
+mox3
 nose

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -22,7 +22,7 @@ import select
 import shutil
 import socket
 import ssl
-import stubout
+from mox3 import stubout
 import sys
 import tempfile
 import unittest

--- a/tests/test_websocketproxy.py
+++ b/tests/test_websocketproxy.py
@@ -20,7 +20,7 @@ import unittest
 import unittest
 import socket
 
-import stubout
+from mox3 import stubout
 
 from websockify import websocket
 from websockify import websocketproxy


### PR DESCRIPTION
mox is pretty much unmaintained these days, however the OpenStack
project are actively maintaining mox3 (a Python 3 compatibile fork
with some other improvements).

websockify seems quite happy to use mox3 instead, so switch the
test dependency and associated imports to use mox3.