### PR TITLE
TCP_KEEPCNT doesn't exist in non-linux

### DIFF
--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -324,8 +324,9 @@ class WebSocketServerTestCase(unittest.TestCase):
                              tcp_keepidle=keepidle,
                              tcp_keepintvl=keepintvl)
 
-        self.assertEqual(sock.getsockopt(socket.SOL_TCP,
-                                         socket.TCP_KEEPCNT), keepcnt)
+        if hasattr(socket, 'TCP_KEEPCNT'):
+            self.assertEqual(sock.getsockopt(socket.SOL_TCP,
+                                             socket.TCP_KEEPCNT), keepcnt)
         self.assertEqual(sock.getsockopt(socket.SOL_TCP,
                                          socket.TCP_KEEPIDLE), keepidle)
         self.assertEqual(sock.getsockopt(socket.SOL_TCP,
@@ -337,8 +338,9 @@ class WebSocketServerTestCase(unittest.TestCase):
                              tcp_keepidle=keepidle,
                              tcp_keepintvl=keepintvl)
 
-        self.assertNotEqual(sock.getsockopt(socket.SOL_TCP,
-                                            socket.TCP_KEEPCNT), keepcnt)
+        if hasattr(socket, 'TCP_KEEPCNT'):
+            self.assertNotEqual(sock.getsockopt(socket.SOL_TCP,
+                                                socket.TCP_KEEPCNT), keepcnt)
         self.assertNotEqual(sock.getsockopt(socket.SOL_TCP,
                                             socket.TCP_KEEPIDLE), keepidle)
         self.assertNotEqual(sock.getsockopt(socket.SOL_TCP,

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -723,8 +723,11 @@ class WebSocketServer(object):
             if  tcp_keepalive:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 if tcp_keepcnt:
-                    sock.setsockopt(socket.SOL_TCP, socket.TCP_KEEPCNT,
-                                    tcp_keepcnt)
+                    if hasattr(socket, 'TCP_KEEPCNT'):
+                        sock.setsockopt(socket.SOL_TCP, socket.TCP_KEEPCNT,
+                                        tcp_keepcnt)
+                    else:
+                        self.msg('tcp_keepcnt not available on your system')
                 if tcp_keepidle:
                     sock.setsockopt(socket.SOL_TCP, socket.TCP_KEEPIDLE,
                                     tcp_keepidle)


### PR DESCRIPTION
The TCP_KEEPCNT option for sockets only work with the Linux kernel,
this isn't available for example in FreeBSD and Hurd, which makes the
package fail to build on these platforms. See Debian bug here:

https://bugs.debian.org/840035