### PR TITLE
Make dependencies for Token plugins optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,11 @@ setup(name=name,
       include_package_data=True,
       install_requires=[
         'numpy', 'requests',
-        'jwcrypto',
-        'redis',
         ],
+      extras_requires={
+        'redis': ['redis'],
+        'jwt': ['jwcrypto'],
+        },
       zip_safe=False,
       entry_points={
         'console_scripts': [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,5 @@ mock
 nose2
 six
 redis
+jwcrypto
 wrapt<=1.12.1;python_version<="3.4"


### PR DESCRIPTION
redis and jwcrypto are not required to use websockify so configure these as optional requirements for specific features (redis, jwt) rather than always installing.