### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/websockify/websocketproxy.py
+++ b/websockify/websocketproxy.py
@@ -439,8 +439,8 @@ def select_ssl_version(version):
         keys.sort()
         fallback = keys[-1]
         logger = logging.getLogger(WebSocketProxy.log_prefix)
-        logger.warn("TLS version %s unsupported. Falling back to %s",
-                    version, fallback)
+        logger.warning("TLS version %s unsupported. Falling back to %s",
+                       version, fallback)
 
         return SSL_OPTIONS[fallback]
 

--- a/websockify/websockifyserver.py
+++ b/websockify/websockifyserver.py
@@ -112,7 +112,7 @@ class WebSockifyRequestHandler(WebSocketRequestHandlerMixIn, SimpleHTTPRequestHa
     def warn(self, msg, *args, **kwargs):
         """ Same as msg() but as warning. """
         prefix = "% 3d: " % self.handler_id
-        self.logger.log(logging.WARN, "%s%s" % (prefix, msg), *args, **kwargs)
+        self.logger.log(logging.WARNING, "%s%s" % (prefix, msg), *args, **kwargs)
 
     #
     # Main WebSocketRequestHandler methods
@@ -627,7 +627,7 @@ class WebSockifyServer():
 
     def warn(self, *args, **kwargs):
         """ Same as msg() but as warning. """
-        self.logger.log(logging.WARN, *args, **kwargs)
+        self.logger.log(logging.WARNING, *args, **kwargs)
 
 
     #
@@ -735,7 +735,7 @@ class WebSockifyServer():
                                     tcp_keepidle=self.tcp_keepidle,
                                     tcp_keepintvl=self.tcp_keepintvl)
         except OSError as e:
-            self.msg("Openening socket failed: %s", str(e))
+            self.msg("Opening socket failed: %s", str(e))
             self.vmsg("exception", exc_info=True)
             sys.exit()
 


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
This small PR resolves those warnings.
