### PR TITLE
Fix iterating over files in dir with pathlib

### DIFF
--- a/websockify/token_plugins.py
+++ b/websockify/token_plugins.py
@@ -45,7 +45,7 @@ class ReadOnlyTokenFile(BasePlugin):
     def _load_targets(self):
         source = Path(self.source)
         if source.is_dir():
-            cfg_files = [file for file in source if file.is_file()]
+            cfg_files = [file for file in source.iterdir() if file.is_file()]
         else:
             cfg_files = [source]
 


### PR DESCRIPTION
PosixPath-objects aren't iterable and we need to call the iterdir()-method if we want to loop over files in the current dir-Path.

This fixes #612.