### PR TITLE
Remove six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'numpy',
         'requests',
-        'jwcrypto',
+        'jwcrypto>=0.9.0',
         'redis',
     ],
     zip_safe=False,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 nose2
-redis

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 nose2
-six
 redis


### PR DESCRIPTION
It was added due to the implicit dependency by jwcrypto, which was fixed in v0.9.0[1]. The library was even removed in jwcrypto v1.0.0[2] and is useless now.

[1] https://github.com/latchset/jwcrypto/commit/08cae6a43ef39a2a8f6148e
[2] https://github.com/latchset/jwcrypto/commit/1f5e7517142baf5eed23578