### PR TITLE
Fix broken symmetric jws token unit tests

### DIFF
--- a/tests/fixtures/symmetric.key
+++ b/tests/fixtures/symmetric.key
@@ -1,1 +1,1 @@
-secret_sauce
+secret_sauce_secret_sauce_secret_sauce_secret_sauce


### PR DESCRIPTION
A 256 bit key length has been enforced in jwcrypto v1.57. 

Please refer to:
https://github.com/latchset/jwcrypto/releases/tag/v1.5.7
https://github.com/latchset/jwcrypto/pull/369