### PR TITLE
Mark Python 3.13 supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     python_requires='>=3.6',
     keywords='noVNC websockify',


### PR DESCRIPTION
Unit tests have been run on Python 3.13 for some time.