### PR TITLE
Replace test symmetric key

### DIFF
--- a/tests/fixtures/symmetric.key
+++ b/tests/fixtures/symmetric.key
@@ -1,1 +1,1 @@
-secret_sauce
+mesGV8j0k2hJf5sl83NMrQeMsA3FOmkEOgqvVe1HBgw


### PR DESCRIPTION
jwcrypto 1.5.7 introduced the validation to enforce key length, which is not met by the existing test key.

Replace it by the new one which has 256 bits length.

Closes #637