### PR TITLE
fix(websocket): strip whitespace from Sec-WebSocket-Protocol tokens

### DIFF
--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -87,6 +87,20 @@ class AcceptTestCase(unittest.TestCase):
         self.assertEqual(sock.data[:13], b'HTTP/1.1 101 ')
         self.assertTrue(b'\r\nSec-WebSocket-Protocol: gazonk\r\n' in sock.data)
 
+    def test_protocol_with_space_after_comma(self):
+        class ProtoSocket(websocket.WebSocket):
+            def select_subprotocol(self, protocol):
+                return 'gazonk'
+
+        ws = ProtoSocket()
+        sock = FakeSocket()
+        ws.accept(sock, {'upgrade': 'websocket',
+                         'Sec-WebSocket-Version': '13',
+                         'Sec-WebSocket-Key': 'DKURYVK9cRFul1vOZVA56Q==',
+                         'Sec-WebSocket-Protocol': 'foobar, gazonk'})
+        self.assertEqual(sock.data[:13], b'HTTP/1.1 101 ')
+        self.assertTrue(b'\r\nSec-WebSocket-Protocol: gazonk\r\n' in sock.data)
+
     def test_no_protocol(self):
         ws = websocket.WebSocket()
         sock = FakeSocket()

--- a/websockify/websocket.py
+++ b/websockify/websocket.py
@@ -281,7 +281,9 @@ class WebSocket:
             accept = b64encode(accept).decode("ascii")
 
             self.protocol = ''
-            protocols = headers.get('Sec-WebSocket-Protocol', '').split(',')
+            # Tokens may be separated by ", " so strip whitespace per RFC 7230
+            protocols = [p.strip() for p in
+                         headers.get('Sec-WebSocket-Protocol', '').split(',')]
             if protocols:
                 self.protocol = self.select_subprotocol(protocols)
                 # We are required to choose one of the protocols


### PR DESCRIPTION
When a client sends `Sec-WebSocket-Protocol: foobar, gazonk` (a space after the comma, as produced by Node's built-in WebSocket client), `split(',')` yields `' gazonk'` with leading whitespace so the subprotocol match fails. Each token is now stripped before matching. Closes #632.